### PR TITLE
Use - instead _

### DIFF
--- a/docs/menu-customization.md
+++ b/docs/menu-customization.md
@@ -1,5 +1,5 @@
 ---
-id: menu_customization
+id: menu-customization
 title: Menu Customization
 sidebar_label: Menu Customization
 slug: '/'

--- a/sidebars.js
+++ b/sidebars.js
@@ -1,6 +1,6 @@
 module.exports = {
   someSidebar: {
-    Docusaurus: ['menu_customization', 'troubleshooting'],
+    Docusaurus: ['menu-customization', 'troubleshooting'],
     Features: ['mdx'],
   },
 };


### PR DESCRIPTION
This is probably a personal taste, but also aligns with Docusaurus' [example](https://github.com/facebook/docusaurus/tree/master/docs) and the url style of many websites like StackOverflow, blogs like Medium.