### PR TITLE
Clojure major mode documentation

### DIFF
--- a/docs/major-mode.md
+++ b/docs/major-mode.md
@@ -22,6 +22,15 @@ The vast majority of major mode specific key bindings will require the installat
 In the following you can see all the currently available major modes.
 If your favorite one is missing, please [contribute](https://github.com/VSpaceCode/VSpaceCode/blob/master/CONTRIBUTING.md)!
 
+## Clojure
+
+Required extensions:
+- [Calva](https://marketplace.visualstudio.com/items?itemName=betterthantomorrow.calva)
+
+Documentation:
+- [VSpaceCode and Calva install guide](http://practicalli.github.io/clojure/clojure-editors/editor-install-guides/vspacecode-calva.html#install-vs-code-extension)
+- [VSpaceCode and Calva user guide](http://practicalli.github.io/clojure/clojure-editors/editor-user-guides/vspacecode-calva.html)
+
 ## Go
 
 Required extensions:


### PR DESCRIPTION
Add links to Calva extension on VS Code marketplace, which provides the Clojure
environment.

Link to install and user guides by Practicalli

Relates to: https://github.com/VSpaceCode/VSpaceCode/pull/154