### PR TITLE
Documentation writing

### DIFF
--- a/docs/whichkey/extra.md
+++ b/docs/whichkey/extra.md
@@ -3,7 +3,7 @@ id: extra
 title: Extra
 ---
 
-This section config extra settings that pertain to both Standalone or With extension.
+This section contains extra config settings that pertain to both Standalone or With extension.
 
 ## Use non-character keys
 
@@ -12,7 +12,7 @@ This section describes a way to use non-character keys in which-key menu like `<
 
 Merge the following json to your `keybindings.json`.
 
-```json
+```jsonc
 {
   "key": "ctrl+x",
   "command": "whichkey.triggerKey",
@@ -26,7 +26,7 @@ Effectively, the above keybinding will enter `C-x` in the QuickPick input box wh
 
 ## Display menu with a delay
 
-You can set `whichkey.delay` in `settings.json` to value in millisecond to delay the display of the menu.
+You can set `whichkey.delay` in `settings.json` to a value in milliseconds to delay the display of the menu.
 
 ## Display menu items alphabetically
 
@@ -34,11 +34,11 @@ You can set `whichkey.sortOrder` in `settings.json` to `alphabetically` to alway
 
 ## Unclear selection
 
-Selected text can be hard to see when which-key menu is active.
-This could be due to the `inactiveSelectionBackground` config of your current theme.
+Selected text can be hard to see when the which-key menu is active due to your current theme's `inactiveSelectionBackground` config.
 You can selectively override that color in your `settings.json` like the following example.
 
-```json
+
+```jsonc
 "workbench.colorCustomizations": {
     "editor.inactiveSelectionBackground": "color that works better",
 },
@@ -77,23 +77,23 @@ See [the relevant issue](https://github.com/VSpaceCode/vscode-which-key/issues/3
 ## Conditional bindings (experimental)
 
 :::caution
-This feature is marked as experimental and the config is subject to change.
+This feature is marked as experimental, and the config is subject to change.
 :::
 
-This allows conditional execution of bindings.
-Currently, it only supports conditions on the `when` passed from shortcut and `languageId` of the active editor.
+This allows the conditional execution of bindings.
+Currently, it only supports conditions on the `when` passed from a shortcut and `languageId` of the active editor.
 
-- It reuses the similar structure to the `bindings` type.
+- It reuses a structure similar to the `bindings` type.
 - The property `key` in a binding item is reused to represent the condition.
 - The condition can be thought of as a key-value pair serialized into a string.
 
 `languageId:javascript;when:sideBarVisible` is an example condition serialized into a string for the `key`
-that checks if the language id of the currently active editor is javascript and if the side bar is visible
+that checks if the language id of the currently active editor is javascript and if the sidebar is visible
 (see the [when](#when) section for more details).
 
-A concrete example of a binding with that condition is as follow:
+A concrete example of a binding with that condition is as follows:
 
-```json
+```jsonc
 {
   "whichkey.bindings": [
     {
@@ -128,18 +128,18 @@ A concrete example of a binding with that condition is as follow:
 
 In this example, when `m` is pressed, it will find the first binding that matches the current condition.
 If no configured key matches the current condition, a default item showing a buffer menu will be used.
-Any item that has an invalid key will be used as default item.
+Any item that has an invalid key will be used as the default item.
 
 Therefore, in this example, if the language is javascript and the sidebar is visible, `m` will open
 the file browser, otherwise it will show the "buffers" menu.
 
 ### Overrides
 
-This is again similar with the `bindings` type.
+This reuses a structure similar to the `bindings` type.
 
 For example, the following config will override the `m` binding completely:
 
-```json
+```jsonc
 {
   "whichkey.bindingOverrides": [
     {
@@ -175,7 +175,7 @@ For example, the following will add a key of `languageId:javascript` to the cond
 }
 ```
 
-Negative `position` property can also be used to remove conditional bindings.
+A negative `position` property can also be used to remove conditional bindings.
 
 ### when
 
@@ -186,10 +186,10 @@ For this reason, you will need to repeat every `when` condition used in conditio
 For example, the following shortcut in `keybindings.json` will pass both `key` and `when` in the `args` to `which-key`.
 The outer `when` is the [condition clause](https://code.visualstudio.com/docs/getstarted/keybindings#_when-clause-contexts)
 for vscode to execute this key, and must contain `whichKeyVisible` which limits this shortcut to be only applicable when the which-key menu is visible.
-In this case, if a user presses key `t` when which-key, sidebar and explorer viewlet are visible, it will execute `whichkey.triggerKey`
+In this case, if a user presses key `t` when which-key, sidebar, and explorer viewlet are visible, it will execute `whichkey.triggerKey`
 command and send the `args` (`key` and `when`) to  `which-key`
 
-```json
+```jsonc
 {
   "key": "t",
   "command": "whichkey.triggerKey",
@@ -201,10 +201,10 @@ command and send the `args` (`key` and `when`) to  `which-key`
 }
 ```
 
-The `args.key` and `args.when` that were sent to `which-key` are then used to find the a binding that matches the key `t`
+The `args.key` and `args.when` that were sent to `which-key` are then used to find a binding that matches the key `t`
 and any conditional binding that matches that condition. The following binding is an example that contains a conditional binding that matches the `args`.
 
-```json
+```jsonc
 {
   "key": "t",
   "name": "Show tree/explorer view",
@@ -227,8 +227,8 @@ and any conditional binding that matches that condition. The following binding i
 ```
 
 Unfortunately, if you have another condition binding with a different `key` that want to match the same
-`when` condition as the `t` in the above example, you will need to setup another shortcut with that different `key`.
+`when` condition as the `t` in the above example, you will need to set up another shortcut with that different `key`.
 
 ### languageId
 
-This is language id of the active editor. The language id can be found in language selection menu inside the parenthesis next to the language name.
+This is the language id of the active editor. The language id can be found in language selection menu inside the parenthesis next to the language name.

--- a/docs/whichkey/extra.md
+++ b/docs/whichkey/extra.md
@@ -37,7 +37,6 @@ You can set `whichkey.sortOrder` in `settings.json` to `alphabetically` to alway
 Selected text can be hard to see when the which-key menu is active due to your current theme's `inactiveSelectionBackground` config.
 You can selectively override that color in your `settings.json` like the following example.
 
-
 ```jsonc
 "workbench.colorCustomizations": {
     "editor.inactiveSelectionBackground": "color that works better",

--- a/docs/whichkey/reference.md
+++ b/docs/whichkey/reference.md
@@ -3,11 +3,11 @@ id: reference
 title: Reference
 ---
 
-Which-key extension aims to provide a keybinding popup similar to
+The which-key extension aims to provide a keybinding popup similar to
 [emacs-which-key](https://github.com/justbur/emacs-which-key)
 by using the [QuickPick](https://code.visualstudio.com/api/references/vscode-api#QuickPick)
 API from vscode.
-This extension was broken out of [`VSpaceCode`](./../installation.md), which was created to emulate the keybinding of spacemacs in VSCode,
+This extension was born from [`VSpaceCode`](./../installation.md), which was created to emulate the keybinding of spacemacs in VSCode,
 to decouple the core and the definition of the bindings.
 
 ## Commands
@@ -42,7 +42,7 @@ Args:
 ```
 
 Description:
-A command to register config which-key so a canonical record of the bindings lives in memory.
+A command to register config which-key, so a canonical record of the bindings lives in memory.
 
 - `bindings` is the configuration location of the bindings. e.g. `vspacecode.bindings`.
 - `overrides` is the configuration location of the overrides. e.g. `vspacecode.overrides`.
@@ -61,8 +61,9 @@ A command used primarily for accepting non-characters key in which-key menu and 
 
 #### Non-character key
 
-The which-key menu relies on QuickPick's input. Because it is a text input, we cannot capture non-character keys like arrow keys, tab key, and keys with
-modifier like `C-x`. We can capture those keys using vscode shortcut with `whichkeyVisible` as `when` clause of the shortcut.
+The which-key menu relies on QuickPick's input. We cannot capture non-character keys like arrow keys, the tab key, and keys with
+modifiers like `C-x`, because they are not text input. We can capture those keys using vscode shortcuts with `whichkeyVisible` in
+the `when` clause of the shortcuts.
 See [Extra](extra#use-non-character-keys) page for more details on usage.
 :::
 
@@ -70,8 +71,8 @@ See [Extra](extra#use-non-character-keys) page for more details on usage.
 
 #### Pass-in when clause
 
-Since vscode doesn't allow extension to read context key-value ([vscode#10471](https://github.com/microsoft/vscode/issues/10471)),
-we will have to relied on `when` clause evaluation in vscode shortcut to pass the context to which-key.
+Since vscode doesn't allow an extension to read context key-values ([vscode#10471](https://github.com/microsoft/vscode/issues/10471)),
+we have to rely on the `when` clause evaluation in a vscode shortcut to pass the context to which-key.
 See [conditional bindings](./extra.md#when) for more details on the usage.
 :::
 
@@ -81,7 +82,7 @@ Command: `whichkey.searchBindings`
 
 Description:
 This is similar to [helm-descbinds](https://github.com/emacs-helm/helm-descbinds) which can search and execute the binding ([vscode-which-key#12](https://github.com/VSpaceCode/vscode-which-key/issues/12)).
-Note that you can only search bindings menu for the currently displayed which-key bindings and their sub-bindings.
+Note that you can only search the bindings menu for the currently displayed which-key bindings and their sub-bindings.
 
 ### Show Transient
 
@@ -100,7 +101,7 @@ Show a transient menu with the definition in the argument.
 Command: `whichkey.repeatRecent`
 
 Description:
-A command to show a which-key menu with key 1 to 9 to repeat the most recently executed command bindings.
+A command to show a which-key menu with keys 1 to 9 to repeat the most recently executed command bindings.
 
 ### Recent Most Recent
 
@@ -121,16 +122,16 @@ A command to toggle zen mode for transient menu, which will show/hide all the me
 Command: `whichkey.openFile`
 
 Description:
-This is a command to get around an issue where vscode doesn't provide a single cross platform command to open file.
+A command to get around an issue where vscode doesn't provide a single cross-platform command to open files.
 See [vscode-which-key#26](https://github.com/VSpaceCode/vscode-which-key/issues/26).
 
 ## Context
 
-The extension will also set the following context when applicable so it can be used in `when` clause of vscode shortcuts.
+The extension will also set the following context when applicable to be used in the `when` clause of vscode shortcuts.
 
 - `whichkeyActive` is a boolean that will be set to `true` when whichkey is active which
   includes the time during the command execution with the menu being hidden.
-  This is rarely used and in most of the use cases it can be replaced with `whichKeyVisible`.
+  This is rarely used, and in most of the use cases, it can be replaced with `whichKeyVisible`.
 
 - `whichkeyVisible` is a boolean that will be set to `true` when the whichkey menu is visible.
   Note that this will be `false` when the transient menu is visible.
@@ -151,8 +152,8 @@ Default: `0`
 
 Description:
 Delay (in milliseconds) for the which-key menu items to be displayed.
-Setting this to positive value will just delay the display of the which-key menu items, while
-key input remains functional.
+Setting this to a positive value will only delay showing the which-key menu items while
+key inputs remain functional.
 
 ### Show Icons
 
@@ -163,7 +164,7 @@ Type: `boolean`
 Default: `true`
 
 Description:
-Controls whether to show or hide icons in which-key menu.
+This option controls whether to show or hide icons in the which-key menu.
 
 ### Sort Order
 
@@ -174,7 +175,7 @@ Type: `"none"` | `"alphabetically"` | `"nonNumberFirst"`
 Default: `"none"`
 
 Description:
-Controls the sorting order of the which-key menu items.
+This option controls the sorting order of the which-key menu items.
 
 - `"none"` will not sort the bindings.
 - `"alphabetically"` will sort the bindings alphabetically using [`String.prototype.localeCompare()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare).
@@ -187,7 +188,7 @@ Key: `whichkey.bindings`
 Type: `Array<BindingItem>`
 
 Description:
-The configuration of the default which-key menu. This contains the array of [`BindingItem`](#bindingitem).
+This contains the default which-key menu and is an array of [`BindingItem`](#bindingitem).
 
 ### Transient Bindings
 
@@ -196,7 +197,7 @@ Key: `whichkey.transient`
 Type: `object`
 
 Description:
-A key-value pair to store default definitions of transient menu for command `whichkey.showTransient` to reference.
+A key-value pair to store default definitions of the transient menu for the `whichkey.showTransient` command to reference.
 
 ## Shortcuts
 
@@ -205,7 +206,7 @@ The whichkey extension contributes the following shortcuts, which means they wil
 `TAB` when `whichKeyVisible` will execute `whichkey.triggerKey` with `\t` as argument to which-key in order to capture of tab `TAB` key.
 
 `C-h` when `whichKeyVisible` will execute `whichkey.describeBindings`, which will show the describe binding menu for the bindings
-(and its sub bindings) which-key currently displayed.
+(and its sub bindings) which-key currently displays.
 
 ## Types
 
@@ -224,10 +225,10 @@ The whichkey extension contributes the following shortcuts, which means they wil
 - Command type indicates a single command will be executed on selection.
 - Commands type indicates multiple commands will be executed on selection.
 - Bindings type indicates that another sub-menu with the supplied bindings will be displayed upon menu item selection.
-- Transient type is similar to bindings type except the menu will not disappear on selection.
+- Transient type is similar to the bindings type, except the menu will not disappear on selection.
 The transient type is being deprecated in favor of the separate command `whichkey.showTransient`.
 All current definitions of transient type are converted internally at the moment.
-- Conditional type is an experimental feature which provides conditional binding behavior. See [Extra](extra/#conditional-bindings-experimental)
+- Conditional type is an experimental feature that provides conditional binding behavior. See [Extra](extra/#conditional-bindings-experimental)
 
 ### BindingItem
 
@@ -249,13 +250,13 @@ All current definitions of transient type are converted internally at the moment
 - `icon` is an optional string property (e.g. `rocket`) used for the display of vscode [product icons](https://code.visualstudio.com/api/references/icons-in-labels)
 as a prefix in the menu item
 - `type` specifies the type of this binding. see [`bindingtype`](#bindingtype)
-- `bindings` is an optional property that is used with binding, transient and conditional type.
+- `bindings` is an optional property that is used with binding transient and conditional types.
 - `command` is an optional property used with command binding type.
-- `commands` is an optional property used with commands binding type. An array of command string is expected.
+- `commands` is an optional property used with commands binding type. An array of command strings is expected.
 - `args` is an optional property that is used to supply arguments to commands for `"command"` or `"commands"`.
 When `"command"` is used, the `args` will be passed directly to the command being executed.
 When `"commands"` is used, an array of the arguments is expected if argument passing is needed.
-`null` can be used to indicate no arguments for a specific position if any subsequent command require an arg.
+`null` can be used to indicate no arguments for a specific position if any subsequent command requires an arg.
 
 ### TransientMenuConfig
 
@@ -287,8 +288,8 @@ When `"commands"` is used, an array of the arguments is expected if argument pas
 as a prefix in the menu item
 - `exit` is an optional boolean property. When it is set to `true`, the transient menu will exit on selection of this item.
 - `command` is an optional property used with command binding type.
-- `commands` is an optional property used with commands binding type. An array of command string is expected.
+- `commands` is an optional property used with commands binding type. An array of command strings is expected.
 - `args` is an optional property that is used to supply arguments to commands for `"command"` or `"commands"`.
 When `"command"` is used, the `args` will be passed directly to the command being executed.
 When `"commands"` is used, an array of the arguments is expected if argument passing is needed.
-`null` can be used to indicate no arguments for a specific position if any subsequent command require an arg.
+`null` can be used to indicate no arguments for a specific position if any subsequent command requires an arg.

--- a/docs/whichkey/usage.md
+++ b/docs/whichkey/usage.md
@@ -14,7 +14,7 @@ This extension comes with a default that didn't have any third-party dependencie
 
 If you want a better default behavior design for VSCode Vim, checkout [VSpaceCode](https://github.com/VSpaceCode/VSpaceCode).
 
-Add the menu key as follows in `settings.json`. This following example is to let VSCode Vim to
+Add the menu key as follows in `settings.json`. The following example is to let VSCode Vim to
 capture the `space` key and trigger the action menu in normal mode and visual mode.
 
 :::tip
@@ -23,10 +23,10 @@ To access `settings.json`, you can search `Setting` in the command list with `Ct
 
 :::caution
 If you have existing config for `vim.normalModeKeyBindingsNonRecursive` or `vim.visualModeKeyBindingsNonRecursive`,
-make sure you add to the array instead of replace them.
+make sure you are adding to the array instead of replacing them.
 :::
 
-```json
+```jsonc
 "vim.normalModeKeyBindingsNonRecursive": [
   {
     "before": ["<space>"],
@@ -54,14 +54,14 @@ You can also bind a customize menu with Vim directly
 
 ### Setup: I am *not* using VSCode Vim
 
-Add the command as follows in `keybindings.json`. This following json is an example to bind `alt+space` to the action menu when a text editor is in focus.
+Add the command as follows in `keybindings.json`. The following json is an example to bind `alt+space` to the action menu when a text editor is in focus.
 
 :::tip
 To access `keybindings.json`, you can search `Keyboard` in the command list with `Ctl+Shift+P` or `Cmd+Shift+P`
 and select `Preference: Open Keyboard Shortcuts (JSON)`.
 :::
 
-```json
+```jsonc
 {
   "key": "alt+space",
   "command": "whichkey.show",
@@ -73,11 +73,11 @@ and select `Preference: Open Keyboard Shortcuts (JSON)`.
 
 There are two ways to customize the menu: incrementally, and from scratch.
 Incrementally is great for when you only need to modify a few bindings from the default.
-Customizing from scratch is great for total control and the customization.
+Customizing from scratch is great for total control and customization.
 
 :::note
 The default bindings are subject to change before `1.0.0`.
-If you find something you that think it should bind to a particular key by default,
+If you find something you think should be bound to a particular key by default
 or you want a particular command, please open an issue as a feature request.
 :::
 
@@ -89,8 +89,8 @@ The extension will override bindings sequentially base on `whichkey.bindingOverr
 #### Add/Replace
 
 The following json will replace `<SPC> g s` in the same position if the binding exists in `whichkey.bindings`,
-and append `s` to menu `<SPC> g` if it doesn't exists. This override will only execute if `<SPC> g` menu exists.
-An optional `position` key can be used to specified index of where the item should be inserted/moved to.
+and append `s` to menu `<SPC> g` if it doesn't exist. This override will only execute if `<SPC> g` menu exists.
+An optional `position` key can be used to specify the index of where the item should be inserted/moved to.
 
 ```jsonc
 {
@@ -131,7 +131,7 @@ If the key binding's key uses character `.` like `<SPC> e .`, you can target tha
 
 #### Removal
 
-Any negative number in position is denoting a removal operation. In the following example, any item bound to `<SPC> g s` will be remove.
+Any negative number in `position` denotes a removal operation. In the following example, any item bound to `<SPC> g s` will be removed.
 
 ```jsonc
 {
@@ -149,9 +149,9 @@ Any negative number in position is denoting a removal operation. In the followin
 To customize the menu items from scratch, you can override the menu completely by putting your own `whichkey.bindings` into your `settings.json`.
 Using this option will prevent any update to your own bindings.
 
-An example of a `settings.json` file that overrides space menu is as follows:
+An example of a `settings.json` file that overrides the space menu is as follows:
 
-```json
+```jsonc
 {
   "whichkey.bindings": [
     {
@@ -195,22 +195,22 @@ You can use the default value as an example to craft your own custom menu.
 
 ## With extension
 
-If you writing an extension and wanting to have which key functionality, you can bundle it with the extension pack feature of vscode.
-There is two mode of operation.
+If you are writing an extension and want to have which key functionality, you can bundle it with the extension pack feature of vscode.
+There are two modes of operation.
 
 To bundle `which-key` to your extension, you can add `VSpaceCode.whichkey` to the `extensionDependencies` of your `package.json`.
-This will install `which-key` on upon installation of your extension and make sure `which-key` is activated before your extension.
+This will install `which-key` upon installation of your extension and make sure `which-key` is activated before your extension.
 
 ### Read from config
 
-This mode will let `which-key` to mange the reading of the config from user's `settings.json`.
+This mode will let `which-key` mange the reading of the config from the user's `settings.json`.
 `which-key` will load the specified config portion and update when the config is updated.
-This is suitable for large menu that might take a bit time to load.
+This is suitable for a large menu that might take a bit of time to load.
 
 1. Register to the location of the config
 
-    The follow extension will tell `which-key` the bindings is living in `myExtension.bindings`,
-    have an optional override config in `myExtension.bindingOverrides`, and have a title of `My Menu`.
+    The following code will tell `which-key` about the bindings living in `myExtension.bindings`,
+    which have an optional override config in `myExtension.bindingOverrides`, and have a title of `My Menu`.
     Note that overrides and title are optional.
 
     ```javascript
@@ -224,7 +224,7 @@ This is suitable for large menu that might take a bit time to load.
 2. Launch the menu
 
     Once you registered the config location, the menu will be loaded, so the launch of the menu can be as quick as possible.
-    The follow code is an example to launch a registered menu.
+    The following code is an example that launches a registered menu.
 
     ```javascript
     commands.executeCommand("whichkey.show", "myExtension.bindings");


### PR DESCRIPTION
This PR updates the writing of the which-key documentation.

A few points that require further discussion:
- which key is written out many ways in this documentation and there should be some uniformity. Some variations I saw were: "which-key", "which key", "whichkey", "Which Key". What is the preferred name?
- the code blocks use `json` and `jsonc`. I changed the code blocks to use `jsonc` for consistency.  If this is unwanted, please let me know.
- some properties in the writing make more sense to have a code block around them. For example, `whichkey.show`.  there were words that did not have a backtick block around them, that should/could have them. I did not touch those. I can go back and add them if necessary.
- the word side bar is spelled in two words, but I believe it should be one word.