### PR TITLE
 Update convention to be move aligned to LSP layer

### DIFF
--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -35,3 +35,25 @@ The following formatting bindings should be offered in all major modes that uses
 | `m a f`     | Execute fix action      | `editor.action.quickFix`     |
 | `m a r`     | Execute refactor action | `editor.action.refactor`     |
 | `m a s`     | Execute source action   | `editor.action.sourceAction` |
+
+### Go to
+
+| Key Binding | Name                      | Command                             |
+| ----------- | ------------------------- | ----------------------------------- |
+| `m g d`     | Go to definition          | `editor.action.revealDefinition`    |
+| `m g h`     | Show call hierarchy       | `references-view.showCallHierarchy` |
+| `m g i`     | Go to implementation      | `editor.action.goToImplementation`  |
+| `m g r`     | Find references           | `references-view.findReferences`    |
+| `m g s`     | Go to symbol in buffer    | `workbench.action.gotoSymbol`       |
+| `m g t`     | Go to type definition     | `editor.action.goToTypeDefinition`  |
+| `m g S`     | Go to symbol in workspace | `workbench.action.showAllSymbols`   |
+
+### Peek
+
+| Key Binding | Name                 | Command                                 |
+| ----------- | -------------------- | --------------------------------------- |
+| `m G d`     | Peek definition      | `editor.action.peekDefinition`          |
+| `m G h`     | Peek call hierarchy  | `editor.showCallHierarchy`              |
+| `m G i`     | Peek implementation  | `editor.action.peekImplementation`      |
+| `m G r`     | Peek references      | `editor.action.referenceSearch.trigger` |
+| `m G t`     | Peek type definition | `editor.action.peekTypeDefinition`      |


### PR DESCRIPTION
The "Go to" menu is pretty common in major mode. This is the common one that we implemented. However, it is not exactly compatible with [LSP layer](https://develop.spacemacs.org/layers/+tools/lsp/README.html#core-key-bindings).

Discussion: Maybe we should standardized one that's base on lap layer. Note, this bindings in the PR is not compatible with LSP layer from spacemacs