### PR TITLE
[major mode] updated Clojure install and user guide

### DIFF
--- a/docs/major-mode.md
+++ b/docs/major-mode.md
@@ -45,7 +45,7 @@ Required extensions:
 
 Documentation:
 
-- [Practicalli VSpaceCode](https://practical.li/vspacecode/) install & guide for VSpaceCode and Calva for Clojure development (updated Febrary 2023)
+- [Practicalli VSpaceCode](https://practical.li/vspacecode/) install & guide for VSpaceCode and Calva for Clojure development
 
 ## Coq
 

--- a/docs/major-mode.md
+++ b/docs/major-mode.md
@@ -45,7 +45,7 @@ Required extensions:
 
 Documentation:
 
-- [Practicalli VSpaceCode](https://practical.li/vspacecode/) - an install and user guide for VSpaceCode and Calva for Clojure development (updated Febrary 2023)
+- [Practicalli VSpaceCode](https://practical.li/vspacecode/) install & guide for VSpaceCode and Calva for Clojure development (updated Febrary 2023)
 
 ## Coq
 

--- a/docs/major-mode.md
+++ b/docs/major-mode.md
@@ -45,8 +45,7 @@ Required extensions:
 
 Documentation:
 
-- [VSpaceCode and Calva install guide](http://practicalli.github.io/clojure/clojure-editors/editor-install-guides/vspacecode-calva.html#install-vs-code-extension)
-- [VSpaceCode and Calva user guide](http://practicalli.github.io/clojure/clojure-editors/editor-user-guides/vspacecode-calva.html)
+- [Practicalli VSpaceCode](https://practical.li/vspacecode/) - an install and user guide for VSpaceCode and Calva for Clojure development (updated Febrary 2023)
 
 ## Coq
 


### PR DESCRIPTION
Install and user guide has been extracted from Practicalli Clojure and a new Practicalli VSpaceCode book has been created.

The install guide and user guide have been re-written and new screenshots taken.  Further content on developing with VSpaceCode will be added to this new book to enhance the user experience

https://practical.li/vspacecode/