### PR TITLE
Added Elixir to major modes docs

### DIFF
--- a/docs/major-mode.md
+++ b/docs/major-mode.md
@@ -79,6 +79,12 @@ Required extensions:
 - [Dart](https://marketplace.visualstudio.com/items?itemName=Dart-Code.dart-code)
 - [Flutter](https://marketplace.visualstudio.com/items?itemName=Dart-Code.flutter)
 
+## Elixir
+
+Required extensions:
+
+- [ElixirLS](https://marketplace.visualstudio.com/items?itemName=JakeBecker.elixir-ls)
+
 ## Go
 
 Required extensions:


### PR DESCRIPTION
Update the docs to add Elixir as a major mode!

Works in tandem with VSpaceCode change https://github.com/VSpaceCode/VSpaceCode/pull/344.

Updates:
- Default Keybindings doc with the new Elixir major mode bindings
- Major Modes doc with required Elixir LS extension