### PR TITLE
chore: remove github button

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -75,14 +75,6 @@ function Home() {
                 >
                   Get Started
                 </Link>
-                <iframe
-                  src="https://ghbtns.com/github-btn.html?user=VSpaceCode&repo=VSpaceCode&type=star&count=true&size=large"
-                  frameBorder="0"
-                  scrolling="0"
-                  width="135"
-                  height="30"
-                  title="GitHub Starts"
-                />
               </div>
             </div>
             <div className="col col--8">


### PR DESCRIPTION
![image](https://github.com/VSpaceCode/vspacecode.github.io/assets/11428655/cc10bd25-d481-4b53-9c71-741c782b73bb)
I'm removing the github button because it uses cookies and we don't have a cookie banner.

We can reintroduce it later by having a github logo svg or something similar.
![image](https://github.com/VSpaceCode/vspacecode.github.io/assets/11428655/2c53676f-2a5d-4b4b-9141-4eee88c16538)

